### PR TITLE
When getting users IP address first check HTTP_X_FORWARDED_FOR

### DIFF
--- a/src/Cogworks.SiteLock/Web/HttpModules/RequestProcessor.cs
+++ b/src/Cogworks.SiteLock/Web/HttpModules/RequestProcessor.cs
@@ -25,7 +25,7 @@ namespace Cogworks.SiteLock.Web.HttpModules
 
             if (RequestHelper.IsLockedDomain(_config, requestUri.Host))
             {
-                if (RequestHelper.IsAllowedIP(_config, httpContext.Request.UserHostAddress)) { return; }
+                if (RequestHelper.IsAllowedIP(_config, GetUserHostAddress(httpContext))) { return; }
 
                 if (RequestHelper.IsAllowedReferrerPath(_config, absolutePath, urlReferrer)) { return; }
 
@@ -41,6 +41,27 @@ namespace Cogworks.SiteLock.Web.HttpModules
                     throw new HttpException(403, "Locked by Cogworks.SiteLock Module");
                 }
             }
+        }
+
+        /// <summary>
+        /// Attempt to get the IP address of the client (as a string)
+        /// </summary>
+        /// <returns></returns>
+        private static string GetUserHostAddress(HttpContextBase httpContext)
+        {
+            string ipAddress = httpContext.Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
+
+            if (!string.IsNullOrEmpty(ipAddress))
+            {
+                string[] ipAddresses = ipAddress.Split(',');
+
+                if (ipAddresses.Length != 0)
+                {
+                    return ipAddresses[0];
+                }
+            }
+
+            return httpContext.Request.ServerVariables["REMOTE_ADDR"];
         }
     }
 }

--- a/src/Tests/Cogworks.SiteLock.Test/When_Processing_Request.cs
+++ b/src/Tests/Cogworks.SiteLock.Test/When_Processing_Request.cs
@@ -40,8 +40,10 @@ namespace Cogworks.SiteLock.Test
 
             _uriStub = new Uri("http://thecogworks.com" + AbsolutePath);
             _httpRequestMock.Setup(x => x.Url).Returns(_uriStub);
-
-            _httpRequestMock.Setup(x => x.UserHostAddress).Returns("8.8.8.8");
+            _httpRequestMock.Setup(x => x.ServerVariables).Returns(new System.Collections.Specialized.NameValueCollection{
+                    { "HTTP_X_FORWARDED_FOR", "8.8.8.8, 4.4.4.4:18104" },
+                    { "REMOTE_ADDR", "8.8.8.8" }
+            });
 
             _contextMock.Setup(x => x.Request).Returns(_httpRequestMock.Object);
             _contextMock.Setup(x => x.Response).Returns(_httpResponseMock.Object);


### PR DESCRIPTION
When getting users IP address first check HTTP_X_FORWARDED_FOR header to support requests from proxy servers such as Cloudflare